### PR TITLE
Use base background color

### DIFF
--- a/stylesheets/git-control.less
+++ b/stylesheets/git-control.less
@@ -3,7 +3,7 @@
 
 .git-control {
   color: @text-color;
-  background: @app-background-color;
+  background: @base-background-color;
 
   pre {
     padding: 0;


### PR DESCRIPTION
This PR changes the background color to use the `@base-background-color` variable. It should match better with most themes and make the tab more seamless:

![screen shot 2015-03-04 at 10 46 09 pm](https://cloud.githubusercontent.com/assets/378023/6484694/61ad0acc-c2c1-11e4-80f4-5f4aaa4cabdb.png)

![screen shot 2015-03-04 at 10 45 46 pm](https://cloud.githubusercontent.com/assets/378023/6484698/65534b64-c2c1-11e4-982b-65d03eef4189.png)

![screen shot 2015-03-04 at 10 45 04 pm](https://cloud.githubusercontent.com/assets/378023/6484702/6aadf532-c2c1-11e4-8f77-0b38b466543c.png)
