### PR TITLE
Colour commit text when characters exceed 50

### DIFF
--- a/lib/dialogs/commit-dialog.coffee
+++ b/lib/dialogs/commit-dialog.coffee
@@ -9,7 +9,7 @@ class CommitDialog extends Dialog
         @strong 'Commit'
       @div class: 'body', =>
         @label 'Commit Message'
-        @textarea class: 'native-key-bindings', outlet: 'msg'
+        @textarea class: 'native-key-bindings', outlet: 'msg', keyUp: 'colorLength'
       @div class: 'buttons', =>
         @button class: 'active', click: 'commit', =>
           @i class: 'icon commit'
@@ -21,6 +21,12 @@ class CommitDialog extends Dialog
   activate: ->
     @msg.val('')
     return super()
+
+  colorLength: ->
+    if @msg.val().length > 50
+      @msg.css('color', 'rgb(232, 94, 94)')
+    else
+      @msg.css('color', '')
 
   commit: ->
     @deactivate()

--- a/lib/dialogs/commit-dialog.coffee
+++ b/lib/dialogs/commit-dialog.coffee
@@ -24,9 +24,9 @@ class CommitDialog extends Dialog
 
   colorLength: ->
     if @msg.val().length > 50
-      @msg.css('color', 'rgb(232, 94, 94)')
+      @msg.addClass('over-fifty')
     else
-      @msg.css('color', '')
+      @msg.removeClass('over-fifty')
 
   commit: ->
     @deactivate()

--- a/styles/dialog.less
+++ b/styles/dialog.less
@@ -65,6 +65,9 @@
   textarea {
     height: 150px;
     resize: none;
+    &.over-fifty {
+      color: @text-color-error;
+    }
   }
 
   button {


### PR DESCRIPTION
I found this feature quite helpful whilst using the git plus package. So I thought I would have a go at implementing it in git-control.