### PR TITLE
Preselect tracked files on open

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -66,6 +66,9 @@ parseStatus = (data) -> q.fcall ->
     [type, name] = line.replace(/\ \ /g, ' ').trim().split(' ')
     files.push
       name: name
+      selected: switch type[type.length - 1]
+        when 'C','M','R','D','A' then true
+        else false
       type: switch type[type.length - 1]
         when 'A' then 'added'
         when 'C' then 'modified' #'copied'

--- a/lib/views/file-view.coffee
+++ b/lib/views/file-view.coffee
@@ -23,7 +23,7 @@ class FileView extends View
         @div class: 'action', click: 'selectAll', =>
           @span 'Select'
           @i class: 'icon check'
-          @input class: 'invisible', type: 'checkbox', outlet: 'allCheckbox'
+          @input class: 'invisible', type: 'checkbox', outlet: 'allCheckbox', checked: true
       @div class: 'placeholder', 'No local working copy changes detected'
 
   initialize: ->
@@ -90,6 +90,7 @@ class FileView extends View
 
         @files[file.name] or= name: file.name
         @files[file.name].type = file.type
+        @files[file.name].selected = file.selected
         @append new FileItem(file)
         return
 


### PR DESCRIPTION
###### A simple implementation of `git commit -a`
Preselect files that have been modified and deleted, but new files you have not told Git about are not selected. 

