### PR TITLE
Mark commit messages correctly if too long

### DIFF
--- a/lib/dialogs/commit-dialog.coffee
+++ b/lib/dialogs/commit-dialog.coffee
@@ -23,10 +23,17 @@ class CommitDialog extends Dialog
     return super()
 
   colorLength: ->
-    if @msg.val().length > 50
+    too_long = false
+    for line, i in @msg.val().split("\n")
+      if (i == 0 && line.length > 50) || (i > 0 && line.length > 80)
+        too_long = true
+        break
+
+    if too_long
       @msg.addClass('over-fifty')
     else
       @msg.removeClass('over-fifty')
+    return
 
   commit: ->
     @deactivate()


### PR DESCRIPTION
Fixes #94

Before this fix every commit message that had at least 50 characters
was colored red. Now, commit messages are only being colored, when
either the first line is longer than 50 or any other line is longer
than 80 characters.