### PR TITLE
Fixes #130 Make the GitFlow button optional

### DIFF
--- a/lib/git-control.coffee
+++ b/lib/git-control.coffee
@@ -10,6 +10,7 @@ pane = undefined
 item = undefined
 
 module.exports = GitControl =
+
   activate: (state) ->
     console.log 'GitControl: activate'
 
@@ -45,3 +46,10 @@ module.exports = GitControl =
     return
 
   serialize: ->
+
+  config:
+    showGitFlowButton:
+      title: 'Show GitFlow button'
+      description: 'Show the GitFlow button in the Git Control toolbar'
+      type: 'boolean'
+      default: true

--- a/lib/views/menu-view.coffee
+++ b/lib/views/menu-view.coffee
@@ -11,12 +11,13 @@ items = [
   { id: 'merge', menu: 'Merge', icon: 'merge', type: 'active'}
   { id: 'branch', menu: 'Branch', icon: 'branch', type: 'active'}
   #{ id: 'tag', menu: 'Tag', icon: 'tag'}
-  { id: 'flow', menu: 'GitFlow', icon: 'flow', type: 'active'}
+  { id: 'flow', menu: 'GitFlow', icon: 'flow', type: 'active', showConfig: 'git-control.showGitFlowButton'}
 ]
 
 class MenuItem extends View
   @content: (item) ->
     klass = if item.type is 'active' then '' else 'inactive'
+    klass += if item.showConfig? && !atom.config.get(item.showConfig) then ' hide' else ''
 
     @div class: "item #{klass} #{item.type}", id: "menu#{item.id}", click: 'click', =>
       @div class: "icon large #{item.icon}"
@@ -24,6 +25,11 @@ class MenuItem extends View
 
   initialize: (item) ->
     @item = item
+
+    if item.showConfig?
+      atom.config.observe item.showConfig, (show) ->
+        if show then $("#menu#{item.id}").removeClass('hide')
+        else $("#menu#{item.id}").addClass('hide')
 
   click: ->
     @parentView.click(@item.id)
@@ -45,4 +51,5 @@ class MenuView extends View
       menuItems.removeClass('inactive')
     else
       menuItems.addClass('inactive')
+
     return

--- a/styles/menu.less
+++ b/styles/menu.less
@@ -20,6 +20,10 @@
       cursor: default;
     }
 
+    &.hide {
+      display: none;
+    }
+
     div {
       text-align: center;
       width: 100%;


### PR DESCRIPTION
Adds a setting to the plugin config page that allows the user to hide the
GitFlow button from the toolbar.
The button is visible by default, so the functionality will not change for
existing users. Users who do not use GitFlow however can declutter their
UI a bit.

![Config](https://i.imgur.com/vC5cnm5.png)