### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a first-release, while tested as part of creating this package, it has n
 
 ##GitFlow
 
-For git-flow commands to work, you need to [install git flow](https://github.com/petervanderdoes/gitflow/wiki)
+For git-flow commands to work, you need to [install git flow](https://github.com/petervanderdoes/gitflow-avh/wiki)
 
 then, on mac, do the following:
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/petervanderdoes/gitflow/wiki | https://github.com/petervanderdoes/gitflow-avh/wiki 
