### PR TITLE
No Tag option added to git flow finish dialog

### DIFF
--- a/lib/dialogs/flow-dialog.coffee
+++ b/lib/dialogs/flow-dialog.coffee
@@ -18,6 +18,8 @@ class FlowDialog extends Dialog
         @select class: 'native-key-bindings', outlet: 'branchChoose'
         @label 'Message:', outlet: 'labelMessage'
         @textarea class: 'native-key-bindings', outlet: 'message'
+        @input class: 'native-key-bindings', type: 'checkbox', outlet: 'noTag', id: 'noTag'
+        @label 'No Tag', outlet: 'labelNoTag', for: 'noTag'
       @div class: 'buttons', =>
         @button class: 'active', click: 'flow', =>
           @i class: 'icon flow'
@@ -56,8 +58,11 @@ class FlowDialog extends Dialog
       branchSelected = if (@branchName.val() != '') then @branchName.val() else @branchChoose.val();
       actionSelected = @flowAction.val()
       if(branchSelected? && branchSelected != '')
-        if(actionSelected == "finish" && @message.val()!= '')
-          actionSelected = 'finish -m "'+@message.val()+'"';
+        if(actionSelected == "finish")
+          if(@message.val()!= '')
+            actionSelected += ' -m "'+@message.val()+'"';
+          if(@noTag.prop('checked'))
+            actionSelected += ' -n';
         @parentView.flow(@flowType.val(),actionSelected,branchSelected)
       else
         git.alert "> No branches selected... Git flow action not valid."
@@ -73,6 +78,15 @@ class FlowDialog extends Dialog
       @labelMessage.hide()
     return
 
+  checkNoTagNeeded: ->
+    if(@flowAction.val() == "finish" && (@flowType.val() == "release" || @flowType.val() == "hotfix" ) )
+      @noTag.show()
+      @labelNoTag.show()
+    else
+      @noTag.hide()
+      @labelNoTag.hide()
+    return
+
   flowTypeChange: ->
     if (@flowType.val() == "init")
       @flowAction.hide()
@@ -84,10 +98,12 @@ class FlowDialog extends Dialog
       @flowActionChange()
       @labelBranchName.show()
     @checkMessageNeeded()
+    @checkNoTagNeeded()
     return
 
   flowActionChange: ->
     @checkMessageNeeded()
+    @checkNoTagNeeded()
     if (@flowAction.val() != "start")
       @branchName.hide()
       @branchName.val('')

--- a/spec/dialogs/flow-dialog-spec.coffee
+++ b/spec/dialogs/flow-dialog-spec.coffee
@@ -1,0 +1,126 @@
+git = require '../../lib/git'
+FlowDialog = require '../../lib/dialogs/flow-dialog'
+
+describe "FlowDialog", ->
+  flowDialog = null
+  stashSaveSpy = null
+  stashPopSpy = null
+  gitControlView = null
+
+  beforeEach ->
+    flowDialog = new FlowDialog()
+    spyOn(git, 'getLocalBranch').andReturn('master');
+    flowDialog.activate(['master'])
+
+  it "should not show 'No Tag' option when 'init' flow type is selected", ->
+    flowDialog.flowType.val('init')
+    flowDialog.flowTypeChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'feature' flow type is selected", ->
+    flowDialog.flowType.val('feature')
+    flowDialog.flowTypeChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'hotfix' type and 'start' flow action is selected", ->
+    flowDialog.flowType.val('hotfix')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('start')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'hotfix' type and 'publish' flow action is selected", ->
+    flowDialog.flowType.val('hotfix')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('publish')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'hotfix' type and 'pull' flow action is selected", ->
+    flowDialog.flowType.val('hotfix')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('pull')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'release' type and 'start' flow action is selected", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('start')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'release' type and 'publish' flow action is selected", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('publish')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should not show 'No Tag' option when 'release' type and 'pull' flow action is selected", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('pull')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should show 'No Tag' option when 'hotfix' type and 'finish' flow action is selected", ->
+    flowDialog.flowType.val('hotfix')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('finish')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).not.toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).not.toBe('none');
+
+  it "should show 'No Tag' option when 'release' type and 'finish' flow action is selected", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('finish')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).not.toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).not.toBe('none');
+
+  it "should hide the 'No Tag' option when switched away from 'finish' flow action", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('finish')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).not.toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).not.toBe('none');
+    flowDialog.flowAction.val('start')
+    flowDialog.flowActionChange()
+    expect(flowDialog.noTag.css('display')).toBe('none');
+    expect(flowDialog.labelNoTag.css('display')).toBe('none');
+
+  it "should call git with -n option when 'No tag' is checked", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('finish')
+    flowDialog.flowActionChange()
+    flowDialog.branchName.val('master')
+    flowDialog.noTag.click()
+    flowSpy = jasmine.createSpy('flow')
+    flowDialog.parentView =
+      flow: flowSpy
+    flowDialog.flow()
+    expect(flowSpy).toHaveBeenCalledWith('release', 'finish -n', 'master');
+
+  it "should call git without -n option when 'No tag' is not checked", ->
+    flowDialog.flowType.val('release')
+    flowDialog.flowTypeChange()
+    flowDialog.flowAction.val('finish')
+    flowDialog.flowActionChange()
+    flowDialog.branchName.val('master')
+    flowSpy = jasmine.createSpy('flow')
+    flowDialog.parentView =
+      flow: flowSpy
+    flowDialog.flow()
+    expect(flowSpy).toHaveBeenCalledWith('release', 'finish', 'master');

--- a/styles/git-control.less
+++ b/styles/git-control.less
@@ -20,4 +20,10 @@
   .clickable {
     cursor: pointer;
   }
+
+  input[type='checkbox'] {
+    width: auto;
+    margin-right: 5px;
+    vertical-align: top;
+  }
 }


### PR DESCRIPTION
Hi. I have added a "No Tag" option to the git flow dialog when release/finish or hotfix/finish is selected. The option adds "-n don't tag this release" argument to the git command.