### PR TITLE
"Interface" word is interpreted twice in "GUI interface"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What
 
-Provides a GUI interface to manage all commonly-used git commands.
+Provides a GUI to manage all commonly-used git commands.
 
 This is a first-release, while tested as part of creating this package, it has not been extensively used on much larger projects. In short: there are possibly still some issues remaining. At the same time, wanted to get the package out there and used.
 


### PR DESCRIPTION
_'GUI interface'_ is technically wrong, since I in GUI stands for interface. 

So _'GUI interface'_ will actually sound like "Graphical User Interface interface". Its the similar mistake as _'HIV virus'_, where V in HIV stands for Virus. 

Its a small things, but worth noticeable.
