### PR TITLE
Custom git executable path configuration added.

### DIFF
--- a/lib/git-control.coffee
+++ b/lib/git-control.coffee
@@ -69,3 +69,8 @@ module.exports = GitControl =
       description: 'Disable Fast Forward for default at Git Merge'
       type: 'boolean'
       default: false
+    gitCustomPath:
+      title: 'Git path'
+      description: 'Git executable location for custom installation'
+      type: 'string'
+      default: ''

--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -93,7 +93,12 @@ parseDefault = (data) -> q.fcall ->
 callGit = (cmd, parser, nodatalog) ->
   logcb "> git #{cmd}"
 
-  return git(cmd, {cwd: cwd})
+  options = {cwd: cwd}
+  customPath = atom.config.get("git-control.gitCustomPath")
+  if customPath
+    options.gitExec = customPath
+
+  return git(cmd, options)
     .then (data) ->
       logcb data unless nodatalog
       return parser(data)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "git-promise": "^0.2.0",
+    "git-promise": "^0.3.1",
     "q": "^1.0.1",
     "atom-space-pen-views": "^2.0.3"
   },
@@ -126,7 +126,7 @@
       },
       {
         "name": "git-promise",
-        "version": "0.2.0",
+        "version": "0.3.1",
         "path": "node_modules/git-promise/index.js"
       },
       {
@@ -771,7 +771,7 @@
           "spec"
         ],
         "dependencies": {
-          "git-promise": "^0.2.0",
+          "git-promise": "^0.3.1",
           "q": "^1.0.1",
           "atom-space-pen-views": "^2.0.3"
         }


### PR DESCRIPTION
Allows users to configure the Git executable path.
Should solve #144.

For this to work, I had to upgrade the [git-promise] dependency to v3.0.0+.