### PR TITLE
Fixed deprecation warning of Pane::addItem(item, 0)

### DIFF
--- a/lib/git-control.coffee
+++ b/lib/git-control.coffee
@@ -32,7 +32,7 @@ module.exports = GitControl =
       views.push view
 
       pane = atom.workspace.getActivePane()
-      item = pane.addItem view, 0
+      item = pane.addItem view, {index: 0}
 
       pane.activateItem item
 


### PR DESCRIPTION
A one-line fix of a deprecation warning that atom gave quite explicit instructions for fixing 😆 , but it was bothersome anyway.
Resolves #209 .