### PR TITLE
Remove deprecation warning

### DIFF
--- a/lib/git-control.coffee
+++ b/lib/git-control.coffee
@@ -32,7 +32,7 @@ module.exports = GitControl =
       views.push view
 
       pane = atom.workspace.getActivePane()
-      item = pane.addItem view, 0
+      item = pane.addItem view, index: 0
 
       pane.activateItem item
 


### PR DESCRIPTION
The deprecation due to `Pane::addItem` change is now removed.
The function is called correctly `Pane::addItem(item, {index: 0})`

close #225