### PR TITLE
Set focus by default to 'commit message' and 'tag name' fields

### DIFF
--- a/lib/dialogs/commit-dialog.coffee
+++ b/lib/dialogs/commit-dialog.coffee
@@ -19,8 +19,10 @@ class CommitDialog extends Dialog
           @span 'Cancel'
 
   activate: ->
+    super()
     @msg.val('')
-    return super()
+    @msg.focus()
+    return
 
   colorLength: ->
     too_long = false

--- a/lib/dialogs/create-tag-dialog.coffee
+++ b/lib/dialogs/create-tag-dialog.coffee
@@ -22,6 +22,11 @@ class CreateTagDialog extends Dialog
           @i class: 'icon x'
           @span 'Cancel'
 
+  activate: ->
+    super()
+    @name.focus()
+    return
+    
   tag: ->
     @deactivate()
     @parentView.tag(@Name(), @Href(), @Msg())


### PR DESCRIPTION
Hi,
I found this cool package this weekend, and here is a small contribution. Now the main input fields of both CommitDialog and CreateTagDialog have the focus 

Thanks for this package!