### PR TITLE
Update git-control-view.coffee

### DIFF
--- a/lib/git-control-view.coffee
+++ b/lib/git-control-view.coffee
@@ -73,7 +73,7 @@ class GitControlView extends View
     if !git.isInitialised()
       git.alert "> This project is not a git repository. Either open another project or create a repository."
     else
-      @setWorkspaceTitle(git.getRepository().path.split('/').reverse()[1])
+      @setWorkspaceTitle(git.getRepository().repo.workingDirectory.split('/').reverse()[1])
     @update(true)
 
     return


### PR DESCRIPTION
This is a fix from split of undefined issue.
Used 'repo.workingDirectory' from gitRepository object instead of 'path' for setWorkspaceTitle. 'path' is no longer available in the object.